### PR TITLE
Buildfixes

### DIFF
--- a/Rusty/Core/Disk.cs
+++ b/Rusty/Core/Disk.cs
@@ -299,6 +299,33 @@ namespace IronAHK.Rusty
             }
         }
 
+        private static void CopyDirectory(string source, string destination, bool overwrite)
+        {
+            try
+            {
+                Directory.CreateDirectory(destination);
+            }
+            catch (IOException)
+            {
+                if (!overwrite)
+                    throw;
+            }
+            
+            foreach (string filepath in Directory.GetFiles(source))
+            {
+                string basename = Path.GetFileName(filepath);
+                string destfile = Path.Combine(destination, basename);
+                File.Copy(filepath, destfile, overwrite);
+            }
+            
+            foreach (string dirpath in Directory.GetDirectories(source))
+            {
+                string basename = Path.GetFileName(dirpath);
+                string destdir = Path.Combine(destination, basename);
+                CopyDirectory(dirpath, destdir, overwrite);
+            }
+        }
+        
         /// <summary>
         /// Copies a folder along with all its sub-folders and files.
         /// </summary>
@@ -318,17 +345,7 @@ namespace IronAHK.Rusty
             {
                 destination = Path.GetFullPath(destination);
 
-                if (Directory.Exists(destination))
-                {
-                    if (overwrite)
-                        return;
-                }
-                else
-                    Directory.CreateDirectory(destination);
-                    if (flag == 1)
-                        Microsoft.VisualBasic.FileIO.FileSystem.CopyDirectory(source, destination, (bool)true);
-                    else
-                        Microsoft.VisualBasic.FileIO.FileSystem.CopyDirectory(source, destination, (bool)false);
+                CopyDirectory(source, destination, overwrite);
             }
             catch (IOException)
             {

--- a/Rusty/Core/Mouse.cs
+++ b/Rusty/Core/Mouse.cs
@@ -55,7 +55,6 @@ namespace IronAHK.Rusty
                 {
                     var foreGroundWindow = Window.WindowItemProvider.Instance.ActiveWindow;
                     if(foreGroundWindow != null) {
-						var name = foreGroundWindow.Title;
                         var location = foreGroundWindow.Location;
                         MousePos.X += location.X;
                         MousePos.Y += location.Y;

--- a/Rusty/Core/Process.cs
+++ b/Rusty/Core/Process.cs
@@ -146,7 +146,7 @@ namespace IronAHK.Rusty
 
                 pid = prc.Id;
             }
-            catch (Exception e)
+            catch (Exception)
             {
                 if (error)
                     ErrorLevel = 2;

--- a/Rusty/Windows/PInvoke.cs
+++ b/Rusty/Windows/PInvoke.cs
@@ -5,6 +5,7 @@ using System.Text;
 
 namespace IronAHK.Rusty
 {
+    [CLSCompliant(false)]
     public partial class WindowsAPI
     {
         const string kernel32 = "kernel32.dll", shell32 = "shell32.dll", user32 = "user32.dll", version = "version.dll", winmm = "winmm.dll";


### PR DESCRIPTION
The first commit is needed to build on Mono and fixes an issue with overwrites in FileCopyDir. The others are warning fixes (unfortunately, the remaining warnings are not as straightforward).
