### PR TITLE
Remove weird things from the Debug configuration.

### DIFF
--- a/IronAHK/Debug.cs
+++ b/IronAHK/Debug.cs
@@ -23,7 +23,7 @@ namespace IronAHK
             internal static extern bool AllocConsole();
         }
 
-        [Conditional("DEBUG")]
+        [Conditional("WTF")]
         static void Start(ref string[] args)
         {
             if (Environment.OSVersion.Platform == PlatformID.Win32NT)

--- a/IronAHK/IronAHK.csproj
+++ b/IronAHK/IronAHK.csproj
@@ -41,7 +41,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DefineConstants>DEBUG</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DebugSymbols>true</DebugSymbols>
@@ -63,6 +63,7 @@
     <AssemblyOriginatorKeyFile>IronAHK.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Scripting/Compiler/CompilerSetup.cs
+++ b/Scripting/Compiler/CompilerSetup.cs
@@ -109,7 +109,7 @@ namespace IronAHK.Scripting
             }
         }
 
-        [Conditional("DEBUG")]
+        [Conditional("TRACE")]
         void Debug(string message)
         {
             Console.WriteLine(message);

--- a/Scripting/Compiler/Emission/MethodSetup.cs
+++ b/Scripting/Compiler/Emission/MethodSetup.cs
@@ -98,7 +98,7 @@ namespace IronAHK.Scripting
             Method.SetCustomAttribute(Attribute);
         }
 
-        [Conditional("DEBUG")]
+        [Conditional("TRACE")]
         void Debug(string Message)
         {
             Console.Write(new string(' ', Depth));

--- a/Scripting/IACodeProvider.cs
+++ b/Scripting/IACodeProvider.cs
@@ -129,7 +129,7 @@ namespace IronAHK.Scripting
 
         #region Helpers
 
-        [Conditional("DEBUG")]
+        [Conditional("TRACE")]
         void PrintCode(CodeCompileUnit[] units, TextWriter writer)
         {
             var gen = new Generator();

--- a/Scripting/Scripting.csproj
+++ b/Scripting/Scripting.csproj
@@ -39,7 +39,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;LEGACY</DefineConstants>
+    <DefineConstants>DEBUG;LEGACY</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DebugSymbols>true</DebugSymbols>
@@ -54,6 +54,7 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -40,7 +40,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DefineConstants>DEBUG</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
@@ -146,6 +146,7 @@
   </ItemGroup>
   <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">


### PR DESCRIPTION
Since Debug is apparently the default in MonoDevelop and is required for
running the tests, it should be a configuration suitable for development.
That means traces (which cause the tests to break) and IronAHK.Program.Start
(which causes my brain to break) are no good. If these are really needed, they
should be in another configuration that defines TRACE or WTF respectively.

I'm not REALLY expecting you to pull this commit unmodified (not that I think there's anything wrong with it), but please do something because not being able to run tests with MonoDevelop is really crappy.
